### PR TITLE
Removing space in formula

### DIFF
--- a/tutorials/build-apps-workflow-check-status/build-apps-workflow-check-status.md
+++ b/tutorials/build-apps-workflow-check-status/build-apps-workflow-check-status.md
@@ -266,7 +266,7 @@ In the previous step, we saved the process ID and status, but the status could h
     Use the following for the formula:
 
     ```JavaScript
-    "/" +  query.Identifier.id
+    "/" + query.Identifier.id
     ``` 
 
     Click **Save** twice.


### PR DESCRIPTION
Removing the space that's causing an issue in the formula. This was reported by a CodeJam attendee.