### PR TITLE
Update DMS_CMIS.postman_collection.json

### DIFF
--- a/projects/dms/DMS_CMIS.postman_collection.json
+++ b/projects/dms/DMS_CMIS.postman_collection.json
@@ -795,7 +795,7 @@
 			},
 			{
 				"key": "accessTokenUrl",
-				"value": "{{authenticationurl}}/oauth/token",
+				"value": "{{authenticationurl}}/oauth/token?grant_type=client_credentials",
 				"type": "string"
 			},
 			{


### PR DESCRIPTION
If you are following the guide at the:
https://community.sap.com/t5/application-development-and-automation-blog-posts/understand-dms-api-free-postman-collection/ba-p/13980756

At the step "Get Token" you get an error:
"Error: invalid_request, Description: Missing grant type"

Solved by add the grant_type in the URL to access to "Get New Access Token"